### PR TITLE
Cleanup workspace after build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,11 +12,11 @@ pipeline {
           }
         }
       }
-    }
-    post {
-      cleanup {
-        script {
-          cleanWs()
+      post {
+        cleanup {
+          script {
+            cleanWs()
+          }
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,5 +13,12 @@ pipeline {
         }
       }
     }
+    post {
+      cleanup {
+        script {
+          cleanWs()
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Previously workspace directory on Jenkins CI did not clean up after build completed. This PR fixes this issue