### PR TITLE
Fix deployment scripts

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -32,7 +32,8 @@ x-healtcheck:
 
 networks:
   sora-net:
-    name: sora-net
+    external:
+      name: sora-net
   traefik-net:
     external:
       name: traefik-net

--- a/deploy/update-and-deploy.sh
+++ b/deploy/update-and-deploy.sh
@@ -16,6 +16,7 @@ sudo docker login --username ${DH_USER} --password ${DH_PASS} ${DH_REPO_URL}
 set -x
 sudo cp ../../sora-env/.env-did-resolver .
 sudo cp ../../sora-env/.env .
+sudo docker network create sora-net || true
 sudo docker-compose -f docker-compose.yml pull
 sudo docker-compose -f docker-compose.yml -p sora down
 sudo docker-compose -f docker-compose.yml -p sora up -d


### PR DESCRIPTION
Signed-off-by: Artyom Bakhtin <a@bakhtin.net>

Since DID resolver is now deployed separately from passport backend it requires attachable shared Docker network. `docker-compose down` was trying to stop containers and remove "unused" Docker network, which in fact could still be in use by passport backend services. Deployment script fails on this step leaving the system not updated.
This fix resolves the problem by creating an external Docker network that is attached by either did-resolver or passport backend services.