### PR TITLE
Fix docker build tags 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,15 +41,16 @@ node(workerLabel) {
           } // end stage
         } // end docker
       } // end if
-      if (scmVars.GIT_LOCAL_BRANCH ==~ /master|develop/) {
+      checkTag = sh(script: "git describe --tags --exact-match ${scmVars.GIT_COMMIT}", returnStatus: true)
+      if (scmVars.GIT_LOCAL_BRANCH ==~ /master|develop/ || checkTag == 0 ) {
+        docker_push_tags = []
         if (scmVars.GIT_LOCAL_BRANCH == 'master')
-          docker_push_tags = ['latest']
-        else
-          docker_push_tags =  ['develop']
-        checkTag = sh(script: "git describe --tags --exact-match ${scmVars.GIT_COMMIT}", returnStatus: true)
-        if (checkTag == 0)
+          docker_push_tags += ['latest']
+        else if (scmVars.GIT_LOCAL_BRANCH == 'develop')
+          docker_push_tags +=  ['develop']
+        else if (checkTag == 0)
           docker_push_tags += [sh(script: "git describe --tags --exact-match ${scmVars.GIT_COMMIT}", returnStdout: true).trim()]
-        print docker_push_tags
+        print "Info: docker_push_tags=${docker_push_tags}"
         docker.image("${dockerImage}-alpine").inside('-v /var/run/docker.sock:/var/run/docker.sock') {
           stage('sonarqube') {
             // push analysis results to sonar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,6 @@ node(workerLabel) {
           docker_push_tags +=  ['develop']
         else if (checkTag == 0)
           docker_push_tags += [sh(script: "git describe --tags --exact-match ${scmVars.GIT_COMMIT}", returnStdout: true).trim()]
-        print "Info: docker_push_tags=${docker_push_tags}"
         docker.image("${dockerImage}-alpine").inside('-v /var/run/docker.sock:/var/run/docker.sock') {
           stage('sonarqube') {
             // push analysis results to sonar
@@ -66,6 +65,7 @@ node(workerLabel) {
               ./gradlew dockerPush -x test -PrepoUrl=${DH_REPO_URL}
             """
             // push git_tag
+            print "Info: docker_push_tags=${docker_push_tags}"
             for ( git_tag in docker_push_tags ){
               sh """#!/bin/sh
                 apk update && apk add docker

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'io.spring.dependency-management'
 apply plugin: "jacoco"
 
 group = 'jp.co.soramitsu.sora'
-version project.properties['version'] ?: '0.0.1-SNAPSHOT'
+version = (findProperty('version') != 'unspecified') ? version : '0.0.1-SNAPSHOT'
 sourceCompatibility = 1.8
 
 ext {

--- a/deploy/update-and-deploy.sh
+++ b/deploy/update-and-deploy.sh
@@ -17,7 +17,7 @@ sudo docker login --username ${DH_USER} --password ${DH_PASS} ${DH_REPO_URL}
 set -x
 sudo cp ../../sora-env/.env-did-resolver .
 sudo cp ../../sora-env/.env .
-echo "VERSION=${VERSION}" | sudo tee -a .env
+echo -e "\nVERSION=${VERSION}" | sudo tee -a .env
 sudo docker network create sora-net || true
 sudo docker-compose -f docker-compose.yml pull
 sudo docker-compose -f docker-compose.yml -p sora down


### PR DESCRIPTION
Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>

1. Recently I change `version = '0.0.1-SNAPSHOT'`  to  `version project.properties['version'] ?: '0.0.1-SNAPSHOT'`
As it turned out ` project.properties['version']` default value already assigned as `unspecified`, we need different default value.

2. If tag(release) was created in GitHub it triggers build in https://jenkins.soramitsu.co.jp/job/sora/job/did-resolver/view/tags/ but build  runs as usual branch because` scmVars.GIT_LOCAL_BRANCH` is a tag name and  it do not match  `if (scmVars.GIT_LOCAL_BRANCH ==~ /master|develop/ ) {` 