### PR TITLE
Disable autodeploy from master branch for Sora project services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 def workerLabel = 'docker-build-agent'
 def deploymentHost = [
-  'develop': ['ubuntu@s1.dev.sora.soramitsu.co.jp'],
-  'master': ['ubuntu@s1.tst.sora.soramitsu.co.jp','ubuntu@s4.stg1.sora.soramitsu.co.jp']]
+  'develop': ['ubuntu@s1.dev.sora.soramitsu.co.jp']]
 def dockerImage = 'openjdk:8'
 def sendTo = 'sora-ci@soramitsu.co.jp'
 def replyTo = 'buildbot@sora.org'


### PR DESCRIPTION
[DOPS-416](https://soramitsu.atlassian.net/browse/DOPS-416)

For Sora backend, Sora admin panel, DID resolver projects automatic deployment from `master` branch should be disabled



Signed-off-by: Bulat Saifullin <bulat@saifullin.ru>